### PR TITLE
Disable javadoc for release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,5 +74,5 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 artifacts {
     archives sourcesJar
-    archives javadocJar
+    // archives javadocJar
 }


### PR DESCRIPTION
temporary workaround for task ':etf-core:checkCommitNeeded'.